### PR TITLE
Fix typo "Wordpress"

### DIFF
--- a/tech-registry/technologies/tools/wordpress.yaml
+++ b/tech-registry/technologies/tools/wordpress.yaml
@@ -1,5 +1,5 @@
 id: wordpress
-name: Wordpress
+name: WordPress
 owner: WordPress
 repo: wordpress-develop
 subreddit: Wordpress


### PR DESCRIPTION
# Pull Request

## Description

WordPress is spelled with an uppercase "P"; also see https://developer.wordpress.org/reference/functions/capital_p_dangit/. 😉