### PR TITLE
Add Clojure and ClojureScript language entries to tech registry

### DIFF
--- a/tech-registry/technologies/languages/clojure.yaml
+++ b/tech-registry/technologies/languages/clojure.yaml
@@ -1,0 +1,9 @@
+id: clojure
+name: Clojure
+description: A dynamic, general-purpose programming language, combining the approachability and interactive development of a scripting language with a robust and efficient infrastructure for multithreaded programming.
+category: language
+creation_year: 2007
+owner: clojure
+repo: clojure
+subreddit: clojure
+stackshare_slug: clojure

--- a/tech-registry/technologies/languages/clojurescript.yaml
+++ b/tech-registry/technologies/languages/clojurescript.yaml
@@ -1,0 +1,9 @@
+id: clojurescript
+name: ClojureScript
+description: A compiler for Clojure that targets JavaScript.
+category: language
+creation_year: 2011
+owner: clojure
+repo: clojurescript
+subreddit: clojurescript
+stackshare_slug: clojurescript


### PR DESCRIPTION
Add metadata for Clojure and ClojureScript.

# Pull Request

## Description

Adding Clojure and ClojureScript as technologies for the DB.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📝 Documentation update (changes to documentation only)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update
- [ ] 🏗️ CI/build changes

## Testing Performed

I ran validate and I booted up the backend to see that both got imported into the database as expected. 

## Screenshots

N/A

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Tech Insight (Optional)

N/A

## Your Tech Funeral Speech (Optional)

Clojure: A Lisp on the JVM, for when you want functional purity and a job market as niche as your syntax.

ClojureScript: Compiling Lisp to JavaScript, because why have one problem when you can have two?
