### PR TITLE
feat(tech-registry): add Actix Web and Axum

### DIFF
--- a/tech-registry/technologies/frameworks/actix-web.yaml
+++ b/tech-registry/technologies/frameworks/actix-web.yaml
@@ -1,0 +1,9 @@
+id: actix-web
+name: Actix Web
+description: A powerful, pragmatic and extremely fast web framework for Rust.
+owner: actix
+repo: actix-web
+subreddit: rust
+stackshare_slug: actix
+creation_year: 2017
+category: framework

--- a/tech-registry/technologies/frameworks/axum.yaml
+++ b/tech-registry/technologies/frameworks/axum.yaml
@@ -1,0 +1,9 @@
+id: axum
+name: Axum
+description: An ergonomic and modular web framework for Rust, built with Tokio, Tower and Hyper.
+owner: tokio-rs
+repo: axum
+subreddit: rust
+stackshare_slug: axum
+creation_year: 2021
+category: framework


### PR DESCRIPTION
# Pull Request

## Description

Adds two Rust web frameworks to the tech registry:

- Actix Web (`actix/actix-web`, 2017)
- Axum (`tokio-rs/axum`, 2021)

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📝 Documentation update (changes to documentation only)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update
- [ ] 🏗️ CI/build changes

## Testing Performed

Ran `npm run validate` in `tech-registry`. All 84 entries are valid.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

Unchecked items do not apply to a data-only registry addition.
